### PR TITLE
Fixed #7 by encoding ASCII-8BIT mails to ISO-8859-1 before encoding t…

### DIFF
--- a/lib/imap_processor.rb
+++ b/lib/imap_processor.rb
@@ -114,10 +114,14 @@ class ImapProcessor
   def encode_entity(entity)
     return nil if entity.nil?
     return entity unless entity.respond_to?('encoding')
-        
+    
     case entity.encoding.name
     when "ASCII-8BIT"
-      entity.force_encoding("ISO-8859-1").encode('utf-8', invalid: :replace, replace: '?')
+      if entity.force_encoding("utf-8").valid_encoding?
+        entity.force_encoding("utf-8")
+      elsif entity.force_encoding("iso-8859-1").valid_encoding?
+        entity.force_encoding("iso-8859-1").encode('utf-8', invalid: :replace, replace: '?')
+      end
     when "UTF-8"
       entity.encode('utf-8', invalid: :replace, replace: '?')
     end

--- a/lib/imap_processor.rb
+++ b/lib/imap_processor.rb
@@ -117,7 +117,7 @@ class ImapProcessor
     
     case entity.encoding.name
     when "ASCII-8BIT"
-      entity.force_encoding("ISO-8859-1").encode('utf-8', invalid: :replace, replace: '?')
+      entity.force_encoding("iso-8859-1").force_encoding("utf-8")
     when "UTF-8"
       entity.encode('utf-8', invalid: :replace, replace: '?')
     end

--- a/lib/imap_processor.rb
+++ b/lib/imap_processor.rb
@@ -117,7 +117,7 @@ class ImapProcessor
     
     case entity.encoding.name
     when "ASCII-8BIT"
-      entity.force_encoding("utf-8")
+      entity.force_encoding("ISO-8859-1").encode('utf-8', invalid: :replace, replace: '?')
     when "UTF-8"
       entity.encode('utf-8', invalid: :replace, replace: '?')
     end

--- a/lib/imap_processor.rb
+++ b/lib/imap_processor.rb
@@ -114,10 +114,10 @@ class ImapProcessor
   def encode_entity(entity)
     return nil if entity.nil?
     return entity unless entity.respond_to?('encoding')
-    
+        
     case entity.encoding.name
     when "ASCII-8BIT"
-      entity.force_encoding("iso-8859-1").force_encoding("utf-8")
+      entity.force_encoding("ISO-8859-1").encode('utf-8', invalid: :replace, replace: '?')
     when "UTF-8"
       entity.encode('utf-8', invalid: :replace, replace: '?')
     end


### PR DESCRIPTION
…hem to the desired UTF-8 format. This is a workaround.

Most emails we get are already encoded in UTF-8, but there are some that are in ISO 8859-1 which is in line with the numbers here: https://w3techs.com/technologies/history_overview/character_encoding. (92% UTF-8, 3,9% ISO 8859-1, for websites). Based on that I assume that there won't be a significant loss by misrepresented characters when we first convert ASCII-8BIT messages to ISO-8859-1 which is an extension for US ASCII.